### PR TITLE
Add arg passthrough to `go test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Usage and documentation
 ------
 ##### Example
 	overalls -project=github.com/bluesuncorp/overalls -covermode=count -debug
-	
+
 ##### then with other tools such as goveralls
 	goveralls -coverprofile=overalls.coverprofile -service semaphore -repotoken $COVERALLS_TOKEN
 
 $ overalls -help
 
-usage: overalls -project=[path] -covermode[mode] OPTIONS
+usage: overalls -project=[path] -covermode[mode] OPTIONS -- TESTOPTIONS
 
 overalls recursively traverses your projects directory structure
 running 'go test -covermode=count -coverprofile=profile.coverprofile'
@@ -43,11 +43,23 @@ OPTIONAL
     A flag indicating whether to print debug messages.
     example: -debug
     default:false
-    
+
+TESTOPTIONS
+
+  Any flags after `--` will be passed as-is to `go test`.
+  For example:
+
+```bash
+overalls -project=$PROJECT -debug -- -race -v
+```
+
+Will call `go test -race -v` under the hood in addition to the `-coverprofile`
+commands.
+
 How to Contribute
 ------
 
-There will always be a development branch. In order to contribute, 
+There will always be a development branch. In order to contribute,
 please make your pull requests against that branch.
 
 If the changes being proposed or requested are breaking changes, please create an issue.

--- a/overalls.go
+++ b/overalls.go
@@ -48,6 +48,7 @@ OPTIONAL
 const (
 	defaultIgnores = ".git,vendor"
 	outFilename    = "overalls.coverprofile"
+	pkgFilename    = "profile.coverprofile"
 )
 
 var (
@@ -148,11 +149,15 @@ func processDIR(wg *sync.WaitGroup, fullPath, relPath string, out chan<- []byte)
 
 	defer wg.Done()
 
+	args := []string{"test"}
+	args = append(args, flag.Args()...)
+	args = append(args, "-covermode="+coverFlag, "-coverprofile="+pkgFilename, "-outputdir="+fullPath+"/", relPath)
+
+	cmd := exec.Command("go", args...)
 	if debugFlag {
-		fmt.Println("Processing: go test -covermode=" + coverFlag + " -coverprofile=profile.coverprofile -outputdir=" + fullPath + "/ " + relPath)
+		fmt.Println("Processing: go", strings.Join(cmd.Args, " "))
 	}
 
-	cmd := exec.Command("go", "test", "-covermode="+coverFlag, "-coverprofile=profile.coverprofile", "-outputdir="+fullPath+"/", relPath)
 	if err := cmd.Run(); err != nil {
 		fmt.Println("ERROR:", err)
 		os.Exit(1)

--- a/overalls.go
+++ b/overalls.go
@@ -157,7 +157,9 @@ func processDIR(logger *log.Logger, wg *sync.WaitGroup, fullPath, relPath string
 
 	defer wg.Done()
 
-	args := []string{"test"}
+	// 1 for "test", 4 for coermode, coverprofile, outputdir, relpath
+	args := make([]string, 1, 1+len(flag.Args())+4)
+	args[0] = "test"
 	args = append(args, flag.Args()...)
 	args = append(args, "-covermode="+coverFlag, "-coverprofile="+pkgFilename, "-outputdir="+fullPath+"/", relPath)
 	fmt.Printf("Test args: %+v\n", args)

--- a/overalls.go
+++ b/overalls.go
@@ -158,8 +158,9 @@ func processDIR(wg *sync.WaitGroup, fullPath, relPath string, out chan<- []byte)
 		fmt.Println("Processing: go", strings.Join(cmd.Args, " "))
 	}
 
-	if err := cmd.Run(); err != nil {
-		fmt.Println("ERROR:", err)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("ERROR:", err.Error(), string(output))
 		os.Exit(1)
 	}
 

--- a/overalls_test.go
+++ b/overalls_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"io/ioutil"
-	"os/exec"
+	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -21,18 +24,45 @@ import (
 //
 
 func TestOveralls(t *testing.T) {
+	withTestingOveralls(t, func(output []byte, fileBytes []byte) {
+		final := string(fileBytes)
+		NotEqual(t, strings.Index(final, "main.go"), -1)
+		NotEqual(t, strings.Index(final, "test-files/good/main.go"), -1)
+		NotEqual(t, strings.Index(final, "test-files/good2/main.go"), -1)
+		MatchRegex(t, string(output), "-covermode=count")
+		MatchRegex(t, string(output), "-outputdir=.*/go-playground/overalls/test-files/good")
+	})
+}
 
-	args := []string{"-project=github.com/go-playground/overalls/test-files", "-covermode=count", "-debug"}
+func TestOveralls_WithExtrArguments(t *testing.T) {
+	withTestingOveralls(t, func(output []byte, fileBytes []byte) {
+		final := string(fileBytes)
+		NotEqual(t, strings.Index(final, "main.go"), -1)
 
-	cmd := exec.Command("overalls", args...)
-	err := cmd.Run()
-	Equal(t, err, nil)
+		fmt.Println(string(output))
+	}, "-v")
+}
+
+func withTestingOveralls(t *testing.T, fn func(output []byte, coverage []byte), args ...string) {
+	baseArgs := []string{"-project=github.com/go-playground/overalls/test-files", "-covermode=count", "-debug"}
+	args = append(baseArgs, args...)
+	args = append([]string{"overalls"}, args...)
+	defer stubArgs(args...)()
+
+	out := &bytes.Buffer{}
+	runMain(log.New(out, "", 0))
 
 	fileBytes, err := ioutil.ReadFile(srcPath + "github.com/go-playground/overalls/test-files/overalls.coverprofile")
-	Equal(t, err, nil)
 
-	final := string(fileBytes)
-	NotEqual(t, strings.Index(final, "main.go"), -1)
-	NotEqual(t, strings.Index(final, "test-files/good/main.go"), -1)
-	NotEqual(t, strings.Index(final, "test-files/good2/main.go"), -1)
+	// Ensure no error reading file
+	Equal(t, err, nil)
+	fn(out.Bytes(), fileBytes)
+}
+
+func stubArgs(args ...string) func() {
+	oldArgs := os.Args
+	os.Args = args
+	return func() {
+		os.Args = oldArgs
+	}
 }

--- a/overalls_test.go
+++ b/overalls_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -23,7 +22,7 @@ import (
 // go test -coverprofile cover.out && go tool cover -html=cover.out -o cover.html
 //
 
-func TestOveralls(t *testing.T) {
+func TestOveralls_Default(t *testing.T) {
 	withTestingOveralls(t, func(output []byte, fileBytes []byte) {
 		final := string(fileBytes)
 		NotEqual(t, strings.Index(final, "main.go"), -1)
@@ -31,16 +30,18 @@ func TestOveralls(t *testing.T) {
 		NotEqual(t, strings.Index(final, "test-files/good2/main.go"), -1)
 		MatchRegex(t, string(output), "-covermode=count")
 		MatchRegex(t, string(output), "-outputdir=.*/go-playground/overalls/test-files/good")
+
+		MatchRegex(t, string(output), "go test -covermode=count")
 	})
 }
 
-func TestOveralls_WithExtrArguments(t *testing.T) {
+func TestOveralls_WithExtraArguments(t *testing.T) {
 	withTestingOveralls(t, func(output []byte, fileBytes []byte) {
-		final := string(fileBytes)
-		NotEqual(t, strings.Index(final, "main.go"), -1)
+		MatchRegex(t, string(output), "Processing: go test")
 
-		fmt.Println(string(output))
-	}, "-v")
+		MatchRegex(t, string(output), "=== RUN")
+		MatchRegex(t, string(output), "--- PASS: TestGood")
+	}, "--", "-v")
 }
 
 func withTestingOveralls(t *testing.T, fn func(output []byte, coverage []byte), args ...string) {


### PR DESCRIPTION
Fixes #8 

I also added output for failure messages, which I can break into a separate PR but I think is useful if the tests fail.
