### PR TITLE
Add concurrency flag to limit resource usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ OPTIONAL
     A flag indicating whether to print debug messages.
     example: -debug
     default:false
+
+  -concurrency
+    Limit the number of packages being processed at one time.
+    example: -concurrency=5
+    default: 1000
     
 How to Contribute
 ------


### PR DESCRIPTION
I wrote this because we have a repository that over utilizes packages and we run tests on a resource-constrained VM. In order to not build all packages at the same time (and bring down the VM), I've added an option to use a concurrency limiter so overalls only processes a certain number of packages at a time.

In order to not change current usage for others who don't care, I've set a very high default for the concurrency limit.

Based on http://jmoiron.net/blog/limiting-concurrency-in-go/

I'm not sure if others find this useful or not. If not, we can close this PR.