### PR TITLE
find package in GOPATH rather than assuming the location

### DIFF
--- a/overalls_test.go
+++ b/overalls_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -52,7 +53,7 @@ func withTestingOveralls(t *testing.T, fn func(output []byte, coverage []byte), 
 	out := &bytes.Buffer{}
 	runMain(log.New(out, "", 0))
 
-	fileBytes, err := ioutil.ReadFile(srcPath + "github.com/go-playground/overalls/test-files/overalls.coverprofile")
+	fileBytes, err := ioutil.ReadFile(filepath.Join(srcPath, "github.com/go-playground/overalls/test-files/overalls.coverprofile"))
 
 	// Ensure no error reading file
 	Equal(t, err, nil)


### PR DESCRIPTION
GOPATH can be a colon-delimited list, or (as of 1.8) can be empty; this
teaches overalls how to use go/build to find the src directory, rather
than assuming it's at $GOPATH/src/$PROJECT