### PR TITLE
Coverpkg doc (Issue #25) plus other helpful info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,27 @@ Package overalls
 [![Build Status](https://travis-ci.org/go-playground/overalls.svg?branch=master)](https://travis-ci.org/go-playground/overalls)
 [![GoDoc](https://godoc.org/github.com/go-playground/overalls?status.svg)](https://godoc.org/github.com/go-playground/overalls)
 
-Package overalls takes multi-package go projects, runs test coverage tests on all packages in each directory and finally concatenates into a single file for tools like goveralls.
+Package overalls takes multi-package go projects, runs test coverage tests on all packages in each directory and finally concatenates into a single file for tools like goveralls and codecov.io.
 
 Usage and documentation
 ------
 ##### Example
 	overalls -project=github.com/go-playground/overalls -covermode=count -debug
 
-##### then with other tools such as goveralls
+##### then with other tools such as [goveralls](https://github.com/mattn/goveralls)
 	goveralls -coverprofile=overalls.coverprofile -service semaphore -repotoken $COVERALLS_TOKEN
+	
+##### or [codecov.io](https://github.com/codecov/example-go)
+	mv overalls.coverprofile coverage.txt
+	export CODECOV_TOKEN=###
+ 	bash <(curl -s https://codecov.io/bash)
+
+
+##### note:
+1. goveralls and codecover currently do not calculate coverage the same way as `go tool cover` see [here](https://github.com/mattn/goveralls/issues/103) and [here](https://github.com/codecov/example-go/issues/13).
+
+2. overalls (and go test) by default will not calculate coverage "across" packages. E.g. if a test in package A covers code in package B overalls will not count it. You may or may not want this depending on whether you're more concerned about unit test coverage or integration test coverage. To enable add the coverpkg flag.
+    `overalls -project=github.com/go-playground/overalls -covermode=count -debug -- -coverpkg=./...`
 
 ```shell
 $ overalls -help


### PR DESCRIPTION
Added explanation of how to use the coverpkg flag, codecov example, and links to coverage issues with goveralls and codecov. Overall my hope is that people will see this tool as a reliable way to get coverage considering how many inconsistencies there are with other tools (and general confusion around golang code coverage).