### PR TITLE
Improve statements detection

### DIFF
--- a/overalls.go
+++ b/overalls.go
@@ -246,7 +246,7 @@ func processDIR(logger *log.Logger, wg *sync.WaitGroup, fullPath, relPath string
 			break
 		}
 	}
-	args = append(args, "-covermode="+coverFlag, "-coverprofile="+pkgFilename, "-outputdir="+fullPath+"/", relPath)
+	args = append(args, "-covermode="+coverFlag, "-coverprofile="+pkgFilename, "-outputdir="+fullPath+"/", relPath+"/...")
 	args = append(args, flagArgs...)
 	fmt.Printf("Test args: %+v\n", args)
 


### PR DESCRIPTION
We had a problem with the correctness of statements detection when tests are located in a separate package and have sub-packages so I've made a little change of how `go test` runs - include all sub-packages of the testing one and this fixed the problem. For example [here](https://travis-ci.org/qbeon/webwire-example-postboard/jobs/419719137) is what was happening and [here](https://travis-ci.org/qbeon/webwire-example-postboard/jobs/420452780) is how it works now.