### PR TITLE
Support absolute paths for projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
         on_failure: always
 
 before_install:
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go get -u github.com/gordonklaus/ineffassign
   - go get -u github.com/client9/misspell/cmd/misspell
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-    - 1.7.5
-    - 1.8.1
-    - tip
+  - 1.10.x
+  - 1.11.x
+  - tip
 matrix:
   allow_failures:
     - go: tip

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ coverprofile in your root directory named 'overalls.coverprofile'
 
 OPTIONS
   -project
-	Your project path relative to the '$GOPATH/src' directory
+	Your project path as an absolute path or relative to the '$GOPATH/src' directory
 	example: -project=github.com/go-playground/overalls
 
   -covermode


### PR DESCRIPTION
Allows a user to set an absolute path for the project flag. This will allow projects that use go modules for package management and reside outside of $GOPATH/src to use this tool. 